### PR TITLE
Remove size assert

### DIFF
--- a/src/io.zig
+++ b/src/io.zig
@@ -63,7 +63,6 @@ pub const zcgltf = struct {
             const buffer_view = accessor.buffer_view.?;
 
             assert(accessor.stride == buffer_view.stride or buffer_view.stride == 0);
-            assert(accessor.stride * accessor.count == buffer_view.size);
             assert(buffer_view.buffer.data != null);
 
             const data_addr = @as([*]const u8, @ptrCast(buffer_view.buffer.data)) +


### PR DESCRIPTION
The assertion that the buffer view should strictly contains a view to the primitive it belongs to is sane , however I found that the GLTF Sponza model from the [glTF-Sample-Assets](https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/Sponza) has each of the primitives buffer view containing data for all primitives, not only the subset. In other words, the buffer view is identical for each `glTF primitive index` which views **all** data.

With the assertion, the library fails to load this model. Removing the assert, I can load each submesh with no issues.
Strictly speaking, in this case we found that the `accessor size <= buffer view size` and not `accessor size == buffer view size`.

Therefore, I believe this assertion is too strict and should be removed.

![image](https://github.com/user-attachments/assets/9e1aa45a-0b7c-44ed-af93-623e7e7d9585)


