### PR TITLE
Guard against freeing invalid allocations

### DIFF
--- a/src/memory.zig
+++ b/src/memory.zig
@@ -108,9 +108,12 @@ fn zmeshFree(maybe_ptr: ?*anyopaque) callconv(.c) void {
         mem_mutex.lock();
         defer mem_mutex.unlock();
 
-        const size = mem_allocations.?.fetchRemove(@intFromPtr(ptr)).?.value;
-        const mem = @as([*]align(mem_alignment.toByteUnits()) u8, @ptrCast(@alignCast(ptr)))[0..size];
-        mem_allocator.?.free(mem);
+        const try_get_allocation = mem_allocations.?.fetchRemove(@intFromPtr(ptr));
+        if (try_get_allocation) |alloc| {
+            const size = alloc.value;
+            const mem = @as([*]align(mem_alignment.toByteUnits()) u8, @ptrCast(@alignCast(ptr)))[0..size];
+            mem_allocator.?.free(mem);
+        }
     }
 }
 


### PR DESCRIPTION
Fixes a segfault inside `memory.zig`.

Interesting bug I discovered when loading any GLTF asset from [this asset pack](https://cosmos.leartesstudios.com/environments/stylized-medieval-town).

### Investigation
If we look at `cgltf`'s source code, specifically line 2103:

```c
for (cgltf_size j = 0; j <  data->animations[i].channels_count; ++j)
{
	cgltf_free_extensions(data, data->animations[i].channels[j].extensions, data->animations[i].channels[j].extensions_count);
	cgltf_free_extras(data, &data->animations[i].channels[j].extras);
}

// Line 2103: free behaviour
data->memory.free_func(data->memory.user_data, data->animations[i].channels);
```

We can see that regardless of the size of `data->animations[i].channels_count`, we’ll still call `free_func` on `data->animations[i].channels`.

<img width="414" height="193" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/e793a035-19d0-4bad-af3e-7405ef5db5f6" />

Thanks to the wonders of C arrays, it’s possible to have `channels_count` be zero but `animations[i].channels` contain junk values as opposed to null.

This means we can see the following call:

```zig
zmeshFree(junk_ptr); // junk_ptr = some junk value like 0xffffffffffffff0
```

where `maybe_ptr` is a junk pointer, i.e. of type pointer but not an actual allocation.

### Simple Solution
If we confirm the allocation exists before trying to free it then we can prevent crashes here.

I've tested this against the problem assets and the fix works.