### PR TITLE
Add all attributes

### DIFF
--- a/src/zcgltf.zig
+++ b/src/zcgltf.zig
@@ -38,6 +38,8 @@ pub fn appendMeshPrimitive(
     texcoords0: ?*std.ArrayListUnmanaged([2]f32),
     tangents: ?*std.ArrayListUnmanaged([4]f32),
     colors: ?*std.ArrayListUnmanaged([4]f32),
+    joints: ?*std.ArrayListUnmanaged([4]f32),
+    weights: ?*std.ArrayListUnmanaged([4]f32),
 ) !void {
     assert(mesh_index < data.meshes_count);
     assert(prim_index < data.meshes.?[mesh_index].primitives_count);
@@ -154,10 +156,18 @@ pub fn appendMeshPrimitive(
                     }
                 },
                 .joints => {
-                    return error.NotImplemented;
+                    if (joints) |j| {
+                        assert(accessor.type == .vec4);
+                        const slice = @as([*]const [4]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
+                        try j.appendSlice(allocator, slice);
+                    }
                 },
                 .weights => {
-                    return error.NotImplemented;
+                    if (weights) |w| {
+                        assert(accessor.type == .vec4);
+                        const slice = @as([*]const [4]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
+                        try w.appendSlice(allocator, slice);
+                    }
                 },
                 else => {
                     std.log.err(

--- a/src/zcgltf.zig
+++ b/src/zcgltf.zig
@@ -182,7 +182,7 @@ pub fn appendMeshPrimitive(
                         if (accessor.type == .vec3) {
                             const slice = @as([*]const [3]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
                             var padded_slice: [][4]f32 = try allocator.alloc([4]f32, slice.len);
-                            @memset(padded_slice, [_]f32{0} ** 4);
+                            @memset(padded_slice, [_]f32{1} ** 4); // Pad alpha to 1.0
                             for (slice, 0..) |vertex, i| {
                                 padded_slice[i][0..3].* = vertex;
                             }

--- a/src/zcgltf.zig
+++ b/src/zcgltf.zig
@@ -138,10 +138,26 @@ pub fn appendMeshPrimitive(
                 },
                 .color => {
                     if (colors) |c| {
-                        assert(accessor.type == .vec4);
-                        const slice = @as([*]const [4]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
-                        try c.appendSlice(allocator, slice);
+                        assert(accessor.type == .vec4 or accessor.type == .vec3);
+                        if (accessor.type == .vec3) {
+                            const slice = @as([*]const [3]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
+                            var padded_slice: [][4]f32 = try allocator.alloc([4]f32, slice.len);
+                            @memset(padded_slice, [_]f32{0} ** 4);
+                            for (slice, 0..) |vertex, i| {
+                                padded_slice[i][0..3].* = vertex;
+                            }
+                            try c.appendSlice(allocator, padded_slice);
+                        } else {
+                            const slice = @as([*]const [4]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
+                            try c.appendSlice(allocator, slice);
+                        }
                     }
+                },
+                .joints => {
+                    return error.NotImplemented;
+                },
+                .weights => {
+                    return error.NotImplemented;
                 },
                 else => {
                     std.log.err(

--- a/src/zcgltf.zig
+++ b/src/zcgltf.zig
@@ -27,6 +27,20 @@ pub fn freeData(data: *Data) void {
     free(data);
 }
 
+fn appendAligned(
+    dim: comptime_int,
+    num_vertices: u32,
+    data_addr: [*]const u8,
+    accessor: *Accessor,
+    expected_type: Type,
+    allocator: std.mem.Allocator,
+    list: *std.ArrayListUnmanaged([dim]f32),
+) !void {
+    assert(accessor.type == expected_type);
+    const slice = @as([*]const [dim]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
+    try list.appendSlice(allocator, slice);
+}
+
 pub fn appendMeshPrimitive(
     allocator: std.mem.Allocator,
     data: *Data,
@@ -113,29 +127,53 @@ pub fn appendMeshPrimitive(
 
             switch (attrib.type) {
                 .position => {
-                    assert(accessor.type == .vec3);
-                    const slice = @as([*]const [3]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
-                    try positions.appendSlice(allocator, slice);
+                    try appendAligned(
+                        3,
+                        num_vertices,
+                        data_addr,
+                        accessor,
+                        .vec3,
+                        allocator,
+                        positions,
+                    );
                 },
                 .normal => {
                     if (normals) |n| {
-                        assert(accessor.type == .vec3);
-                        const slice = @as([*]const [3]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
-                        try n.appendSlice(allocator, slice);
+                        try appendAligned(
+                            3,
+                            num_vertices,
+                            data_addr,
+                            accessor,
+                            .vec3,
+                            allocator,
+                            n,
+                        );
                     }
                 },
                 .texcoord => {
                     if (texcoords0) |tc| {
-                        assert(accessor.type == .vec2);
-                        const slice = @as([*]const [2]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
-                        try tc.appendSlice(allocator, slice);
+                        try appendAligned(
+                            2,
+                            num_vertices,
+                            data_addr,
+                            accessor,
+                            .vec2,
+                            allocator,
+                            tc,
+                        );
                     }
                 },
                 .tangent => {
                     if (tangents) |tan| {
-                        assert(accessor.type == .vec4);
-                        const slice = @as([*]const [4]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
-                        try tan.appendSlice(allocator, slice);
+                        try appendAligned(
+                            4,
+                            num_vertices,
+                            data_addr,
+                            accessor,
+                            .vec4,
+                            allocator,
+                            tan,
+                        );
                     }
                 },
                 .color => {
@@ -157,16 +195,28 @@ pub fn appendMeshPrimitive(
                 },
                 .joints => {
                     if (joints) |j| {
-                        assert(accessor.type == .vec4);
-                        const slice = @as([*]const [4]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
-                        try j.appendSlice(allocator, slice);
+                        try appendAligned(
+                            4,
+                            num_vertices,
+                            data_addr,
+                            accessor,
+                            .vec4,
+                            allocator,
+                            j,
+                        );
                     }
                 },
                 .weights => {
                     if (weights) |w| {
-                        assert(accessor.type == .vec4);
-                        const slice = @as([*]const [4]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
-                        try w.appendSlice(allocator, slice);
+                        try appendAligned(
+                            4,
+                            num_vertices,
+                            data_addr,
+                            accessor,
+                            .vec4,
+                            allocator,
+                            w,
+                        );
                     }
                 },
                 else => {

--- a/src/zcgltf.zig
+++ b/src/zcgltf.zig
@@ -187,6 +187,7 @@ pub fn appendMeshPrimitive(
                                 padded_slice[i][0..3].* = vertex;
                             }
                             try c.appendSlice(allocator, padded_slice);
+                            allocator.free(padded_slice);
                         } else {
                             const slice = @as([*]const [4]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
                             try c.appendSlice(allocator, slice);

--- a/src/zcgltf.zig
+++ b/src/zcgltf.zig
@@ -37,6 +37,7 @@ pub fn appendMeshPrimitive(
     normals: ?*std.ArrayListUnmanaged([3]f32),
     texcoords0: ?*std.ArrayListUnmanaged([2]f32),
     tangents: ?*std.ArrayListUnmanaged([4]f32),
+    colors: ?*std.ArrayListUnmanaged([4]f32),
 ) !void {
     assert(mesh_index < data.meshes_count);
     assert(prim_index < data.meshes.?[mesh_index].primitives_count);
@@ -108,28 +109,46 @@ pub fn appendMeshPrimitive(
             const data_addr = @as([*]const u8, @ptrCast(buffer_view.buffer.data)) +
                 accessor.offset + buffer_view.offset;
 
-            if (attrib.type == .position) {
-                assert(accessor.type == .vec3);
-                const slice = @as([*]const [3]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
-                try positions.appendSlice(allocator, slice);
-            } else if (attrib.type == .normal) {
-                if (normals) |n| {
+            switch (attrib.type) {
+                .position => {
                     assert(accessor.type == .vec3);
                     const slice = @as([*]const [3]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
-                    try n.appendSlice(allocator, slice);
-                }
-            } else if (attrib.type == .texcoord) {
-                if (texcoords0) |tc| {
-                    assert(accessor.type == .vec2);
-                    const slice = @as([*]const [2]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
-                    try tc.appendSlice(allocator, slice);
-                }
-            } else if (attrib.type == .tangent) {
-                if (tangents) |tan| {
-                    assert(accessor.type == .vec4);
-                    const slice = @as([*]const [4]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
-                    try tan.appendSlice(allocator, slice);
-                }
+                    try positions.appendSlice(allocator, slice);
+                },
+                .normal => {
+                    if (normals) |n| {
+                        assert(accessor.type == .vec3);
+                        const slice = @as([*]const [3]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
+                        try n.appendSlice(allocator, slice);
+                    }
+                },
+                .texcoord => {
+                    if (texcoords0) |tc| {
+                        assert(accessor.type == .vec2);
+                        const slice = @as([*]const [2]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
+                        try tc.appendSlice(allocator, slice);
+                    }
+                },
+                .tangent => {
+                    if (tangents) |tan| {
+                        assert(accessor.type == .vec4);
+                        const slice = @as([*]const [4]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
+                        try tan.appendSlice(allocator, slice);
+                    }
+                },
+                .color => {
+                    if (colors) |c| {
+                        assert(accessor.type == .vec4);
+                        const slice = @as([*]const [4]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
+                        try c.appendSlice(allocator, slice);
+                    }
+                },
+                else => {
+                    std.log.err(
+                        "Loading of attribute type {?s} is not implemented",
+                        .{attrib.name},
+                    );
+                },
             }
         }
     }

--- a/src/zcgltf.zig
+++ b/src/zcgltf.zig
@@ -29,7 +29,6 @@ pub fn freeData(data: *Data) void {
 
 fn appendAligned(
     dim: comptime_int,
-    num_vertices: u32,
     data_addr: [*]const u8,
     accessor: *Accessor,
     expected_type: Type,
@@ -37,7 +36,10 @@ fn appendAligned(
     list: *std.ArrayListUnmanaged([dim]f32),
 ) !void {
     assert(accessor.type == expected_type);
-    const slice = @as([*]const [dim]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
+    const slice = @as(
+        [*]const [dim]f32,
+        @ptrCast(@alignCast(data_addr)),
+    )[0..accessor.count];
     try list.appendSlice(allocator, slice);
 }
 
@@ -61,7 +63,6 @@ pub fn appendMeshPrimitive(
     const mesh = &data.meshes.?[mesh_index];
     const prim = &mesh.primitives[prim_index];
 
-    const num_vertices: u32 = @as(u32, @intCast(prim.attributes[0].data.count));
     const num_indices: u32 = @as(u32, @intCast(prim.indices.?.count));
 
     // Indices.
@@ -129,7 +130,6 @@ pub fn appendMeshPrimitive(
                 .position => {
                     try appendAligned(
                         3,
-                        num_vertices,
                         data_addr,
                         accessor,
                         .vec3,
@@ -141,7 +141,6 @@ pub fn appendMeshPrimitive(
                     if (normals) |n| {
                         try appendAligned(
                             3,
-                            num_vertices,
                             data_addr,
                             accessor,
                             .vec3,
@@ -154,7 +153,6 @@ pub fn appendMeshPrimitive(
                     if (texcoords0) |tc| {
                         try appendAligned(
                             2,
-                            num_vertices,
                             data_addr,
                             accessor,
                             .vec2,
@@ -167,7 +165,6 @@ pub fn appendMeshPrimitive(
                     if (tangents) |tan| {
                         try appendAligned(
                             4,
-                            num_vertices,
                             data_addr,
                             accessor,
                             .vec4,
@@ -180,7 +177,10 @@ pub fn appendMeshPrimitive(
                     if (colors) |c| {
                         assert(accessor.type == .vec4 or accessor.type == .vec3);
                         if (accessor.type == .vec3) {
-                            const slice = @as([*]const [3]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
+                            const slice = @as(
+                                [*]const [3]f32,
+                                @ptrCast(@alignCast(data_addr)),
+                            )[0..accessor.count];
                             var padded_slice: [][4]f32 = try allocator.alloc([4]f32, slice.len);
                             @memset(padded_slice, [_]f32{1} ** 4); // Pad alpha to 1.0
                             for (slice, 0..) |vertex, i| {
@@ -189,7 +189,10 @@ pub fn appendMeshPrimitive(
                             try c.appendSlice(allocator, padded_slice);
                             allocator.free(padded_slice);
                         } else {
-                            const slice = @as([*]const [4]f32, @ptrCast(@alignCast(data_addr)))[0..num_vertices];
+                            const slice = @as(
+                                [*]const [4]f32,
+                                @ptrCast(@alignCast(data_addr)),
+                            )[0..accessor.count];
                             try c.appendSlice(allocator, slice);
                         }
                     }
@@ -198,7 +201,6 @@ pub fn appendMeshPrimitive(
                     if (joints) |j| {
                         try appendAligned(
                             4,
-                            num_vertices,
                             data_addr,
                             accessor,
                             .vec4,
@@ -211,7 +213,6 @@ pub fn appendMeshPrimitive(
                     if (weights) |w| {
                         try appendAligned(
                             4,
-                            num_vertices,
                             data_addr,
                             accessor,
                             .vec4,


### PR DESCRIPTION
Address #8 and #11, and refactor a tiny bit to keep the code DRY.

I made the decision to always accept a list of RGBA colors as input, and to use padding for RGB-only colors.