### PR TITLE
 Fixup usage of deprecated std.Build APIs, fixup missing CGLTF_API

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -50,22 +50,22 @@ pub fn build(b: *std.Build) void {
 
     b.installArtifact(zmesh_lib);
 
-    zmesh_lib.linkLibC();
+    zmesh_lib.root_module.link_libc = true;
     if (target.result.abi != .msvc)
-        zmesh_lib.linkLibCpp();
+        zmesh_lib.root_module.link_libcpp = true;
 
     const par_shapes_t = if (options.shape_use_32bit_indices)
         "-DPAR_SHAPES_T=uint32_t"
     else
         "-DPAR_SHAPES_T=uint16_t";
 
-    zmesh_lib.addIncludePath(b.path("libs/par_shapes"));
-    zmesh_lib.addCSourceFile(.{
+    zmesh_lib.root_module.addIncludePath(b.path("libs/par_shapes"));
+    zmesh_lib.root_module.addCSourceFile(.{
         .file = b.path("libs/par_shapes/par_shapes.c"),
         .flags = &.{ "-std=c99", "-fno-sanitize=undefined", par_shapes_t },
     });
 
-    zmesh_lib.addCSourceFiles(.{
+    zmesh_lib.root_module.addCSourceFiles(.{
         .files = &.{
             "libs/meshoptimizer/clusterizer.cpp",
             "libs/meshoptimizer/indexgenerator.cpp",
@@ -80,8 +80,8 @@ pub fn build(b: *std.Build) void {
         },
         .flags = &.{""},
     });
-    zmesh_lib.addIncludePath(b.path("libs/cgltf"));
-    zmesh_lib.addCSourceFile(.{
+    zmesh_lib.root_module.addIncludePath(b.path("libs/cgltf"));
+    zmesh_lib.root_module.addCSourceFile(.{
         .file = b.path("libs/cgltf/cgltf.c"),
         .flags = &.{"-std=c99"},
     });
@@ -94,8 +94,8 @@ pub fn build(b: *std.Build) void {
     });
     b.installArtifact(tests);
 
-    tests.linkLibrary(zmesh_lib);
-    tests.addIncludePath(b.path("libs/cgltf"));
+    tests.root_module.linkLibrary(zmesh_lib);
+    tests.root_module.addIncludePath(b.path("libs/cgltf"));
 
     test_step.dependOn(&b.addRunArtifact(tests).step);
 }

--- a/build.zig
+++ b/build.zig
@@ -50,7 +50,7 @@ pub fn build(b: *std.Build) void {
 
     b.installArtifact(zmesh_lib);
 
-    zmesh_lib.root_module.link_libcpp = true;
+    zmesh_lib.root_module.link_libc = true;
     if (target.result.abi != .msvc)
         zmesh_lib.root_module.link_libcpp = true;
 

--- a/build.zig
+++ b/build.zig
@@ -18,8 +18,11 @@ pub fn build(b: *std.Build) void {
     };
 
     const options_step = b.addOptions();
-    inline for (std.meta.fields(@TypeOf(options))) |field| {
-        options_step.addOption(field.type, field.name, @field(options, field.name));
+    inline for (
+        comptime std.meta.fieldTypes(@TypeOf(options)),
+        comptime std.meta.fieldNames(@TypeOf(options)),
+    ) |field_type, field_name| {
+        options_step.addOption(field_type, field_name, @field(options, field_name));
     }
 
     const options_module = options_step.createModule();

--- a/build.zig
+++ b/build.zig
@@ -23,12 +23,22 @@ pub fn build(b: *std.Build) void {
     }
 
     const options_module = options_step.createModule();
+
+    const translate_c = b.addTranslateC(.{
+        .root_source_file = b.path("src/c.h"),
+        .target = target,
+        .optimize = optimize,
+    });
+    translate_c.addIncludePath(b.path("libs/cgltf"));
+    const c_module = translate_c.createModule();
+
     const zmesh_module = b.addModule("root", .{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
             .{ .name = "zmesh_options", .module = options_module },
+            .{ .name = "c", .module = c_module },
         },
     });
 
@@ -80,7 +90,6 @@ pub fn build(b: *std.Build) void {
         },
         .flags = &.{""},
     });
-    zmesh_lib.root_module.addIncludePath(b.path("libs/cgltf"));
     zmesh_lib.root_module.addCSourceFile(.{
         .file = b.path("libs/cgltf/cgltf.c"),
         .flags = &.{"-std=c99"},
@@ -95,7 +104,6 @@ pub fn build(b: *std.Build) void {
     b.installArtifact(tests);
 
     tests.root_module.linkLibrary(zmesh_lib);
-    tests.root_module.addIncludePath(b.path("libs/cgltf"));
 
     test_step.dependOn(&b.addRunArtifact(tests).step);
 }

--- a/libs/cgltf/cgltf.h
+++ b/libs/cgltf/cgltf.h
@@ -97,6 +97,10 @@
 #include <stddef.h>
 #include <stdint.h> /* For uint8_t, uint32_t */
 
+#ifndef CGLTF_API
+#define CGLTF_API
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -840,51 +844,51 @@ typedef struct cgltf_data
 	cgltf_file_options file;
 } cgltf_data;
 
-cgltf_result cgltf_parse(
+CGLTF_API cgltf_result cgltf_parse(
 		const cgltf_options* options,
 		const void* data,
 		cgltf_size size,
 		cgltf_data** out_data);
 
-cgltf_result cgltf_parse_file(
+CGLTF_API cgltf_result cgltf_parse_file(
 		const cgltf_options* options,
 		const char* path,
 		cgltf_data** out_data);
 
-cgltf_result cgltf_load_buffers(
+CGLTF_API cgltf_result cgltf_load_buffers(
 		const cgltf_options* options,
 		cgltf_data* data,
 		const char* gltf_path);
 
-cgltf_result cgltf_load_buffer_base64(const cgltf_options* options, cgltf_size size, const char* base64, void** out_data);
+CGLTF_API cgltf_result cgltf_load_buffer_base64(const cgltf_options* options, cgltf_size size, const char* base64, void** out_data);
 
-cgltf_size cgltf_decode_string(char* string);
-cgltf_size cgltf_decode_uri(char* uri);
+CGLTF_API cgltf_size cgltf_decode_string(char* string);
+CGLTF_API cgltf_size cgltf_decode_uri(char* uri);
 
-cgltf_result cgltf_validate(cgltf_data* data);
+CGLTF_API cgltf_result cgltf_validate(cgltf_data* data);
 
-void cgltf_free(cgltf_data* data);
+CGLTF_API void cgltf_free(cgltf_data* data);
 
-void cgltf_node_transform_local(const cgltf_node* node, cgltf_float* out_matrix);
-void cgltf_node_transform_world(const cgltf_node* node, cgltf_float* out_matrix);
+CGLTF_API void cgltf_node_transform_local(const cgltf_node* node, cgltf_float* out_matrix);
+CGLTF_API void cgltf_node_transform_world(const cgltf_node* node, cgltf_float* out_matrix);
 
-const uint8_t* cgltf_buffer_view_data(const cgltf_buffer_view* view);
+CGLTF_API const uint8_t* cgltf_buffer_view_data(const cgltf_buffer_view* view);
 
-const cgltf_accessor* cgltf_find_accessor(const cgltf_primitive* prim, cgltf_attribute_type type, cgltf_int index);
+CGLTF_API const cgltf_accessor* cgltf_find_accessor(const cgltf_primitive* prim, cgltf_attribute_type type, cgltf_int index);
 
-cgltf_bool cgltf_accessor_read_float(const cgltf_accessor* accessor, cgltf_size index, cgltf_float* out, cgltf_size element_size);
-cgltf_bool cgltf_accessor_read_uint(const cgltf_accessor* accessor, cgltf_size index, cgltf_uint* out, cgltf_size element_size);
-cgltf_size cgltf_accessor_read_index(const cgltf_accessor* accessor, cgltf_size index);
+CGLTF_API cgltf_bool cgltf_accessor_read_float(const cgltf_accessor* accessor, cgltf_size index, cgltf_float* out, cgltf_size element_size);
+CGLTF_API cgltf_bool cgltf_accessor_read_uint(const cgltf_accessor* accessor, cgltf_size index, cgltf_uint* out, cgltf_size element_size);
+CGLTF_API cgltf_size cgltf_accessor_read_index(const cgltf_accessor* accessor, cgltf_size index);
 
 cgltf_size cgltf_num_components(cgltf_type type);
 cgltf_size cgltf_component_size(cgltf_component_type component_type);
 cgltf_size cgltf_calc_size(cgltf_type type, cgltf_component_type component_type);
 
-cgltf_size cgltf_accessor_unpack_floats(const cgltf_accessor* accessor, cgltf_float* out, cgltf_size float_count);
-cgltf_size cgltf_accessor_unpack_indices(const cgltf_accessor* accessor, void* out, cgltf_size out_component_size, cgltf_size index_count);
+CGLTF_API cgltf_size cgltf_accessor_unpack_floats(const cgltf_accessor* accessor, cgltf_float* out, cgltf_size float_count);
+CGLTF_API cgltf_size cgltf_accessor_unpack_indices(const cgltf_accessor* accessor, void* out, cgltf_size out_component_size, cgltf_size index_count);
 
 /* this function is deprecated and will be removed in the future; use cgltf_extras::data instead */
-cgltf_result cgltf_copy_extras_json(const cgltf_data* data, const cgltf_extras* extras, char* dest, cgltf_size* dest_size);
+CGLTF_API cgltf_result cgltf_copy_extras_json(const cgltf_data* data, const cgltf_extras* extras, char* dest, cgltf_size* dest_size);
 
 cgltf_size cgltf_mesh_index(const cgltf_data* data, const cgltf_mesh* object);
 cgltf_size cgltf_material_index(const cgltf_data* data, const cgltf_material* object);

--- a/libs/cgltf/cgltf_write.h
+++ b/libs/cgltf/cgltf_write.h
@@ -35,12 +35,16 @@
 #include <stddef.h>
 #include <stdbool.h>
 
+#ifndef CGLTF_API
+#define CGLTF_API
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-cgltf_result cgltf_write_file(const cgltf_options* options, const char* path, const cgltf_data* data);
-cgltf_size cgltf_write(const cgltf_options* options, char* buffer, cgltf_size size, const cgltf_data* data);
+CGLTF_API cgltf_result cgltf_write_file(const cgltf_options* options, const char* path, const cgltf_data* data);
+CGLTF_API cgltf_size cgltf_write(const cgltf_options* options, char* buffer, cgltf_size size, const cgltf_data* data);
 
 #ifdef __cplusplus
 }

--- a/src/Shape.zig
+++ b/src/Shape.zig
@@ -332,7 +332,7 @@ const expect = std.testing.expect;
 test "zmesh.basic" {
     const zmesh = @import("root.zig");
 
-    zmesh.init(std.testing.allocator);
+    zmesh.init(std.testing.allocator, std.testing.io);
     defer zmesh.deinit();
 
     const cylinder = Shape.initCylinder(10, 10);
@@ -406,7 +406,7 @@ test "zmesh.basic" {
 test "zmesh.clone" {
     const zmesh = @import("root.zig");
 
-    zmesh.init(std.testing.allocator);
+    zmesh.init(std.testing.allocator, std.testing.io);
     defer zmesh.deinit();
 
     const cube = Shape.initCube();
@@ -421,7 +421,7 @@ test "zmesh.clone" {
 test "zmesh.merge" {
     const zmesh = @import("root.zig");
 
-    zmesh.init(std.testing.allocator);
+    zmesh.init(std.testing.allocator, std.testing.io);
     defer zmesh.deinit();
 
     var cube = Shape.initCube();
@@ -441,7 +441,7 @@ test "zmesh.merge" {
 test "zmesh.invert" {
     const zmesh = @import("root.zig");
 
-    zmesh.init(std.testing.allocator);
+    zmesh.init(std.testing.allocator, std.testing.io);
     defer zmesh.deinit();
 
     var hemisphere = Shape.initParametricSphere(10, 10);
@@ -460,7 +460,7 @@ test "zmesh.custom" {
 
     const allocator = std.testing.allocator;
 
-    zmesh.init(allocator);
+    zmesh.init(allocator, std.testing.io);
     defer zmesh.deinit();
 
     var positions: std.ArrayList([3]f32) = .empty;

--- a/src/c.h
+++ b/src/c.h
@@ -1,0 +1,1 @@
+#include "cgltf.h"

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -1,28 +1,15 @@
 const std = @import("std");
 const options = @import("zmesh_options");
 
-const SpinLock = struct {
-    state: u32 = 0,
+pub fn init(alloc: std.mem.Allocator, io: std.Io) void {
+    std.debug.assert(state == null);
 
-    fn lock(s: *SpinLock) void {
-        while (@atomicRmw(u32, &s.state, .Xchg, 1, .seq_cst) != 0) {
-            while (@atomicLoad(u32, &s.state, .acquire) != 0) {
-                std.Thread.yield() catch {};
-            }
-        }
-    }
-
-    fn unlock(s: *SpinLock) void {
-        @atomicStore(u32, &s.state, 0, .release);
-    }
-};
-
-pub fn init(alloc: std.mem.Allocator) void {
-    std.debug.assert(mem_allocator == null and mem_allocations == null);
-
-    mem_allocator = alloc;
-    mem_allocations = std.AutoHashMap(usize, usize).init(alloc);
-    mem_allocations.?.ensureTotalCapacity(32) catch unreachable;
+    state = .{
+        .io = io,
+        .mem_allocator = alloc,
+        .mem_allocations = .init(alloc),
+    };
+    state.?.mem_allocations.ensureTotalCapacity(32) catch unreachable;
 
     const zmeshMallocPtr = @extern(*?*const fn (size: usize) callconv(.c) ?*anyopaque, .{
         .name = "zmeshMallocPtr",
@@ -49,9 +36,8 @@ pub fn init(alloc: std.mem.Allocator) void {
 }
 
 pub fn deinit() void {
-    mem_allocations.?.deinit();
-    mem_allocations = null;
-    mem_allocator = null;
+    state.?.mem_allocations.deinit();
+    state = null;
 }
 
 const MallocFn = *const fn (size: usize) callconv(.c) ?*anyopaque;
@@ -62,23 +48,26 @@ extern fn meshopt_setAllocator(
     deallocate: FreeFn,
 ) void;
 
-var mem_allocator: ?std.mem.Allocator = null;
-var mem_allocations: ?std.AutoHashMap(usize, usize) = null;
-var mem_mutex: SpinLock = .{};
 const mem_alignment: std.mem.Alignment = .@"16";
+pub const GlobalState = struct {
+    io: std.Io,
+    mem_allocator: std.mem.Allocator,
+    mem_allocations: std.AutoHashMap(usize, usize),
+    mem_mutex: std.Io.Mutex = .init,
+};
+var state: ?GlobalState = null;
 
 pub fn zmeshMalloc(size: usize) callconv(.c) ?*anyopaque {
-    mem_mutex.lock();
-    defer mem_mutex.unlock();
+    state.?.mem_mutex.lockUncancelable(state.?.io);
+    defer state.?.mem_mutex.unlock(state.?.io);
 
-    const mem = mem_allocator.?.alignedAlloc(
+    const mem = state.?.mem_allocator.alignedAlloc(
         u8,
         mem_alignment,
         size,
     ) catch @panic("zmesh: out of memory");
 
-    mem_allocations.?.put(@intFromPtr(mem.ptr), size) catch @panic("zmesh: out of memory");
-
+    state.?.mem_allocations.put(@intFromPtr(mem.ptr), size) catch @panic("zmesh: out of memory");
     return mem.ptr;
 }
 
@@ -97,38 +86,38 @@ pub fn zmeshAllocUser(user: ?*anyopaque, size: usize) callconv(.c) ?*anyopaque {
 }
 
 fn zmeshRealloc(ptr: ?*anyopaque, size: usize) callconv(.c) ?*anyopaque {
-    mem_mutex.lock();
-    defer mem_mutex.unlock();
+    state.?.mem_mutex.lockUncancelable(state.?.io);
+    defer state.?.mem_mutex.unlock(state.?.io);
 
-    const old_size = if (ptr != null) mem_allocations.?.get(@intFromPtr(ptr.?)).? else 0;
+    const old_size = if (ptr != null) state.?.mem_allocations.get(@intFromPtr(ptr.?)).? else 0;
 
     const old_mem = if (old_size > 0)
         @as([*]align(mem_alignment.toByteUnits()) u8, @ptrCast(@alignCast(ptr)))[0..old_size]
     else
         @as([*]align(mem_alignment.toByteUnits()) u8, undefined)[0..0];
 
-    const mem = mem_allocator.?.realloc(old_mem, size) catch @panic("zmesh: out of memory");
+    const mem = state.?.mem_allocator.realloc(old_mem, size) catch @panic("zmesh: out of memory");
 
     if (ptr != null) {
-        const removed = mem_allocations.?.remove(@intFromPtr(ptr.?));
+        const removed = state.?.mem_allocations.remove(@intFromPtr(ptr.?));
         std.debug.assert(removed);
     }
 
-    mem_allocations.?.put(@intFromPtr(mem.ptr), size) catch @panic("zmesh: out of memory");
+    state.?.mem_allocations.put(@intFromPtr(mem.ptr), size) catch @panic("zmesh: out of memory");
 
     return mem.ptr;
 }
 
 fn zmeshFree(maybe_ptr: ?*anyopaque) callconv(.c) void {
     if (maybe_ptr) |ptr| {
-        mem_mutex.lock();
-        defer mem_mutex.unlock();
+        state.?.mem_mutex.lockUncancelable(state.?.io);
+        defer state.?.mem_mutex.unlock(state.?.io);
 
-        const try_get_allocation = mem_allocations.?.fetchRemove(@intFromPtr(ptr));
+        const try_get_allocation = state.?.mem_allocations.fetchRemove(@intFromPtr(ptr));
         if (try_get_allocation) |alloc| {
             const size = alloc.value;
             const mem = @as([*]align(mem_alignment.toByteUnits()) u8, @ptrCast(@alignCast(ptr)))[0..size];
-            mem_allocator.?.free(mem);
+            state.?.mem_allocator.free(mem);
         }
     }
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -3,11 +3,10 @@ const std = @import("std");
 pub const Shape = @import("Shape.zig");
 pub const io = @import("io.zig");
 pub const opt = @import("zmeshoptimizer.zig");
-
 pub const mem = @import("memory.zig");
 
-pub fn init(alloc: std.mem.Allocator) void {
-    mem.init(alloc);
+pub fn init(alloc: std.mem.Allocator, io_impl: std.Io) void {
+    mem.init(alloc, io_impl);
 }
 
 pub fn deinit() void {

--- a/src/zcgltf.zig
+++ b/src/zcgltf.zig
@@ -2,6 +2,7 @@ const builtin = @import("builtin");
 const std = @import("std");
 const assert = std.debug.assert;
 const mem = @import("memory.zig");
+const c = @import("c");
 
 pub const Bool32 = i32;
 pub const CString = [*:0]const u8;
@@ -1043,7 +1044,6 @@ test {
 
 test "extern struct layout" {
     @setEvalBranchQuota(10_000);
-    const c = @cImport(@cInclude("cgltf.h"));
     inline for (comptime std.meta.declarations(@This())) |decl| {
         const ZigType = @field(@This(), decl.name);
         if (@TypeOf(ZigType) != type) {
@@ -1079,7 +1079,6 @@ test "extern struct layout" {
 
 test "enum" {
     @setEvalBranchQuota(10_000);
-    const c = @cImport(@cInclude("cgltf.h"));
     inline for (comptime std.meta.declarations(@This())) |decl| {
         const ZigType = @field(@This(), decl.name);
         if (@TypeOf(ZigType) != type) {


### PR DESCRIPTION
These changes are required for zig 0.16.x compatibility, they don't compile against 0.15.2 due to the new Io changes in std.

- Fixup usage of deprecated std.Build APIs
- Restore missing instances of CGLTF_API (removed in https://github.com/zig-gamedev/zmesh/pull/15)
- Move global state in GlobalState (similar to the approach used with zphysics)
- Update to the new std.Io.Mutex API (requires `std.Io`)