### PR TITLE
zcgltf: Fixed bugs on `Material` struct

### DIFF
--- a/src/zcgltf.zig
+++ b/src/zcgltf.zig
@@ -559,7 +559,7 @@ pub const Iridescence = extern struct {
 pub const DiffuseTransmission = extern struct {
     diffuse_transmission_texture: TextureView,
     diffuse_transmission_factor: f32,
-    diffuse_transmission_color_factor: f32,
+    diffuse_transmission_color_factor: [3]f32,
     diffuse_transmission_color_texture: TextureView,
 };
 
@@ -585,8 +585,8 @@ pub const Material = extern struct {
     has_sheen: Bool32,
     has_emissive_strength: Bool32,
     has_iridescence: Bool32,
-    has_anisotropy: Bool32,
     has_diffuse_transmission: Bool32,
+    has_anisotropy: Bool32,
     has_dispersion: Bool32,
     pbr_metallic_roughness: PbrMetallicRoughness,
     pbr_specular_glossiness: PbrSpecularGlossiness,
@@ -598,8 +598,8 @@ pub const Material = extern struct {
     volume: Volume,
     emissive_strength: EmissiveStrength,
     iridescence: Iridescence,
-    anisotropy: Anisotropy,
     diffuse_transmission: DiffuseTransmission,
+    anisotropy: Anisotropy,
     dispersion: Dispersion,
     normal_texture: TextureView,
     occlusion_texture: TextureView,


### PR DESCRIPTION
This PR fixes two bugs on struct `Material` in `zcgltf.zig`.

1. Changed field `diffuse_transmission_color_factor` in struct `DiffuseTransmission` from type `f32` to `[3]f32` (see [cgltf.h](https://github.com/zig-gamedev/zmesh/blob/main/libs/cgltf/cgltf.h#L523)). Before this fix the size of `Material` is 8 byte less, and could cause invalid memory access when loading `gltf` files with more than one materials.

3. Swapped the order of fields `has_anisotropy` with `has_diffuse_transmission`, `anisotropy` with `diffuse_transmission` (see [cgltf.h](https://github.com/zig-gamedev/zmesh/blob/main/libs/cgltf/cgltf.h#L566), line 552-553 and line 566-567).