### PR TITLE
cgltf_accessor_unpack_indices is missing out_component_size parameter

### DIFF
--- a/src/zcgltf.zig
+++ b/src/zcgltf.zig
@@ -391,11 +391,11 @@ pub const Accessor = extern struct {
     }
 
     pub fn unpackIndicesCount(accessor: Accessor) usize {
-        return cgltf_accessor_unpack_indices(&accessor, null, 0);
+        return cgltf_accessor_unpack_indices(&accessor, null, 0, 0);
     }
 
     pub fn unpackIndices(accessor: Accessor, out: []u32) []u32 {
-        const count = cgltf_accessor_unpack_indices(&accessor, out.ptr, out.len);
+        const count = cgltf_accessor_unpack_indices(&accessor, out.ptr, @sizeOf(u32), out.len);
         return out[0..count];
     }
 
@@ -997,6 +997,7 @@ extern fn cgltf_accessor_unpack_floats(
 extern fn cgltf_accessor_unpack_indices(
     accessor: ?*const Accessor,
     out: ?[*]u32,
+    out_component_size: usize,
     index_count: usize,
 ) usize;
 


### PR DESCRIPTION
Calling [`Accessor.unpackIndices`](https://github.com/zig-gamedev/zmesh/blob/a0efcc452eab17550ad5525df2293009e9cbaf66/src/zcgltf.zig#L397) writes 0 bytes of data to the `out` slice because [`cgltf_accessor_unpack_indices`](https://github.com/zig-gamedev/zmesh/blob/a0efcc452eab17550ad5525df2293009e9cbaf66/src/zcgltf.zig#L997) extern definition omits the `out_component_size` ([cgltf source](https://github.com/zig-gamedev/zmesh/blob/a0efcc452eab17550ad5525df2293009e9cbaf66/libs/cgltf/cgltf.h#L884)) parameter so the C function gets called with `out_component_size = out.len`, and `index_count = 0`.